### PR TITLE
Fix C++ files lookup of godot-cpp lib

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -12,22 +12,8 @@ env = SConscript("godot-cpp/SConstruct")
 # - CPPDEFINES are for pre-processor defines
 # - LINKFLAGS are for linking flags
 
-godot_headers_path = "godot-cpp/godot-headers/"
-cpp_bindings_path = "godot-cpp/"
-cpp_library = "godot-cpp"
-
-env.Append(CPPPATH=['.', godot_headers_path, 
-    cpp_bindings_path + 'include/', 
-    cpp_bindings_path + 'include/core/', 
-    cpp_bindings_path + 'include/gen/', 
-    # Added
-    cpp_bindings_path + 'gen/include/',
-    cpp_bindings_path + 'gen/include/godot_cpp/classes/',
-])
-
-
 # tweak this if you want to use different folders, or more folders, to store your source code in.
-# env.Append(CPPPATH=["src/"])
+env.Append(CPPPATH=["src/"])
 sources = Glob("src/*.cpp")
 
 if env["platform"] == "macos":

--- a/src/mysimplegdextension.h
+++ b/src/mysimplegdextension.h
@@ -1,7 +1,7 @@
 #ifndef MYSIMPLEGDEXTENSION_H_INCLUDED
 #define MYSIMPLEGDEXTENSION_H_INCLUDED
 
-#include <sprite2d.hpp>
+#include <godot_cpp/classes/sprite2d.hpp>
 
 namespace godot
 {


### PR DESCRIPTION
This fixes the path in the mysimplegdextension header file
This way you can use all the generated files from the lib. IDE autocompletion should work with this as well.